### PR TITLE
docs: update example to use full semver

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ jobs:
   create_sync_pull_request:
     runs-on: ubuntu-latest
     steps:
-      - uses: dequelabs/action-sync-branches@v1
+      - uses: dequelabs/action-sync-branches@v1.0.0
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           pr-title: "chore: merge master into develop"


### PR DESCRIPTION
One small minor thing I noticed. Our release will tag it as `v1.x.x` so we probably want to match that syntax in the example.

## Reviewer checks

**Required fields, to be filled out by PR reviewer(s)**

- [x] Follows the commit message policy, appropriate for next version
- [x] Code is reviewed for security
