### PR TITLE
chore: update reviewers on sync pull request

### DIFF
--- a/.github/workflows/sync-master-develop.yml
+++ b/.github/workflows/sync-master-develop.yml
@@ -13,5 +13,5 @@ jobs:
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           pr-title: "chore: merge master into develop"
-          pr-team-reviewers: dequelabs/html-team
+          pr-reviewers: scurker,stephenmathieson
           pr-labels: chore


### PR DESCRIPTION
Noticed that we still had `pr-team-reviewers` here, which won't work without a personal access token.

## Reviewer checks

**Required fields, to be filled out by PR reviewer(s)**

- [x] Follows the commit message policy, appropriate for next version
- [x] Code is reviewed for security
