### PR TITLE
fix: avoid "Error: Not Found" when octokit gives status as string instead of number

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -35,7 +35,12 @@ async function run(): Promise<void> {
     })
     pullRequestTemplate = response.data
   } catch (err) {
-    if (err.status === 404 && err.message === 'Not Found') {
+    // Careful; `err.status` can be either a string or a number depending on
+    // octokit version.
+    if (
+      String(err.status) === '404' &&
+      err.message === 'Not Found'
+    ) {
       console.log(
         `Unable to find pr-template "${template}"`
       )


### PR DESCRIPTION
Minimal fix to get usage unblocked, separate PR for following up on getting deps updated/pinned

Closes #45 

Demo of fix working: https://github.com/dequelabs/dbjorge-test-repo/actions/runs/9603704409/job/26487539207

## Reviewer checks

**Required fields, to be filled out by PR reviewer(s)**

- [x] Follows the commit message policy, appropriate for next version
- [x] Code is reviewed for security
